### PR TITLE
Switch form Puppet to OpenVox

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,8 +59,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.19.0 < 9.0.0"
     }
   ],
   "pdk-version": "2.2.0",


### PR DESCRIPTION
Now that Perforce has killed Puppet, we need to switch to OpenVox to run tests. As we cannot run tests with Puppet Core, as it makes no sense to continue testing against legacy Open Source Puppet, and as Puppet 7 has reached EOL, we can drop support for Puppet completely.  People will still be able to send PR to fix issue if they find some with Puppet Core, but we cannot support this setup, and we encourage users to avoid this situation.
